### PR TITLE
Установил белый цвет шрифта для сообщений

### DIFF
--- a/media/main.css
+++ b/media/main.css
@@ -52,6 +52,7 @@ body {
 	padding: 4px;
 	border: 1px solid rgb(30, 60, 70);
 	background-color: rgb(30, 60, 70);
+	color: white;
 }
 
 .user-message {
@@ -60,6 +61,7 @@ body {
 	padding: 4px;
 	border: 1px solid rgb(56, 56, 56);
 	background-color: rgb(56, 56, 56);
+	color: white;
 }
 
 pre {


### PR DESCRIPTION
В светлых темах текст не читается, т.к. меняется на темный, при этом фон в сообщениях тоже темный. Текст становится нечитаемым, пока его не выделить, либо не сменить тему на темную.
![image](https://github.com/user-attachments/assets/cf210377-e990-45f5-9638-b7670e663cd8)
